### PR TITLE
Remove React.StrictMode in index.js, fix isModalOpen in commentForm t…

### DIFF
--- a/src/components/CommentForm.js
+++ b/src/components/CommentForm.js
@@ -7,7 +7,7 @@ const maxLength = (len) => (val) => !val || val.length <= len;
 const minLength = (len) => (val) => val && val.length >= len;
 
 function CommentForm(props) {
-  const [isModalOpen, setIsModalOpen] = useState(0);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const { dishId, addComment } = props;
 
   const toggleModal = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,9 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(
-  <React.StrictMode>
+  <>
     <App />
-  </React.StrictMode>,
+  </>,
   document.getElementById('root')
 );
 


### PR DESCRIPTION
…o set boolean value of false instead of default number to remove error

- react's strictmode raising warning errors in console regarding some reactstrap and bootstrap library using old legacy syntax
- remove strictmode for now and revert back to  fragment since too many warning signs in console = hard to read actual errors
-